### PR TITLE
Fix codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,5 @@
 # Don't change me! Compliance team is the owner of these files
 /.github/                   @saic-oss/compliance
 /.pre-commit-config.yaml    @saic-oss/compliance
-/Taskfile.yaml              @saic-oss/compliance
+/Taskfile.yml               @saic-oss/compliance
+/.remarkrc                  @saic-oss/compliance


### PR DESCRIPTION
## what/why
- Fix typo (.yaml -> .yml)
- @saic-oss/compliance owns .remarkrc
