### PR TITLE
Added timeout to rancher2 cluster sync creation

### DIFF
--- a/rancher.tf
+++ b/rancher.tf
@@ -15,6 +15,9 @@ resource "rancher2_cluster_sync" "default" {
   cluster_id      = rancher2_cluster.default.id
   state_confirm   = 36
   wait_monitoring = false
+  timeouts {
+    create = "60m"
+  }
   depends_on = [
     aws_autoscaling_group.worker,
     aws_autoscaling_group.controlplane,


### PR DESCRIPTION
## what
* Added timeout for create in the rancher2 cluster sync resource

## why
* The create was timing out at the default 30 minutes consistently
